### PR TITLE
Changed a bunch of stuff, cherry pick what you want.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,3 @@ asw.sh takes two integers and scrapes the website for all comics in the range of
 show.sh looks in ~/asw/ for .jpgs, and displays a random one (uses gnome-open, which works for me! no promises).
 
 To setup, mkdir ~/asw/ and run './asw.sh 1 1237' from inside. This will take several minutes to download all the comics. Then run show.sh whenever you want a comic.
-
-TODO: should default to 1-[maxComicIndex], so will have to do some more magic to figure that out.

--- a/asw.sh
+++ b/asw.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-for i in $(seq ${1:-1} ${2:-$(curl -s 'http://asofterworld.com/rssfeed.php' | xmllint --xpath "//item[1]/link/text()" - | grep -Po '\d+')})
-do
-    html=`curl "http://www.asofterworld.com/index.php?id=$i"`;
-    src=`echo $html | sed -n -e 's/.*img width=720 src="//p' | cut -d"\"" -f1`
+for i in $(seq ${1:-1} ${2:-$(curl -s 'http://asofterworld.com/rssfeed.php' | xmllint --xpath "//item[1]/link/text()" - | grep -Po '\d+')}); do
+    src="$(curl -s "http://www.asofterworld.com/index.php?id=$i" | xmllint --html --xpath '//div[@id="comicimg"]/img/@src' - 2>/dev/null | cut -d\" -f2)"
     name=`echo $src | cut -d"/" -f5`
     number=""
     for j in `seq 1 $(expr 4 - ${#i})`

--- a/asw.sh
+++ b/asw.sh
@@ -3,12 +3,7 @@
 for i in $(seq ${1:-1} ${2:-$(curl -s 'http://asofterworld.com/rssfeed.php' | xmllint --xpath "//item[1]/link/text()" - | grep -Po '\d+')}); do
     src="$(curl -s "http://www.asofterworld.com/index.php?id=$i" | xmllint --html --xpath '//div[@id="comicimg"]/img/@src' - 2>/dev/null | cut -d\" -f2)"
     name=`echo $src | cut -d"/" -f5`
-    number=""
-    for j in `seq 1 $(expr 4 - ${#i})`
-    do
-        number=0$number
-    done
-    number=$number$i
+    number="$(printf "%04d" $i)"
     echo $number
     name=$number$name
     echo NAME: $name

--- a/asw.sh
+++ b/asw.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 for i in `seq $1 $2`
 do
     html=`curl "http://www.asofterworld.com/index.php?id=$i"`;

--- a/asw.sh
+++ b/asw.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-for i in `seq $1 $2`
+for i in $(seq ${1:-1} ${2:-$(curl -s 'http://asofterworld.com/rssfeed.php' | xmllint --xpath "//item[1]/link/text()" - | grep -Po '\d+')})
 do
     html=`curl "http://www.asofterworld.com/index.php?id=$i"`;
     src=`echo $html | sed -n -e 's/.*img width=720 src="//p' | cut -d"\"" -f1`

--- a/asw.sh
+++ b/asw.sh
@@ -2,10 +2,6 @@
 
 for i in $(seq ${1:-1} ${2:-$(curl -s 'http://asofterworld.com/rssfeed.php' | xmllint --xpath "//item[1]/link/text()" - | grep -Po '\d+')}); do
     src="$(curl -s "http://www.asofterworld.com/index.php?id=$i" | xmllint --html --xpath '//div[@id="comicimg"]/img/@src' - 2>/dev/null | cut -d\" -f2)"
-    name=`echo $src | cut -d"/" -f5`
-    number="$(printf "%04d" $i)"
-    echo $number
-    name=$number$name
-    echo NAME: $name
+    name="$(printf "%04d$(cut -d/ -f5 <<<"$src")" $i)"
     wget -O $name $src
 done


### PR DESCRIPTION
`asw.sh` now:
- Permits shell executables anywhere in `$PATH`.
- Default ranges to `1-[maxComicIndex]` when arguments aren't provided, 
- Grabs `src` without an intermediate `html` variable.
- Elides its padding loop in favour of a printf.
- Says less: echoing `$number$name` is redundant with 'wget' output.

Altogether fairly drastic, I guess just cherry pick anything you find useful.
